### PR TITLE
Increase algo speed

### DIFF
--- a/results/results_eki_normal.Rmd
+++ b/results/results_eki_normal.Rmd
@@ -57,7 +57,7 @@ prior_params <- list(alpha.mean = 0, alpha.sd = 5,
 In this experiment I keep $\alpha$ and $\sigma^2$ fixed at 2 and 4 respectively and let $x$ be a vector of 1s corresponding to 10, 50 and 100 dimensions. The purpose of this is to see how the EKI algorithm performs when the number of dimensions increases.
 
 ```{r}
-start.time <- Sys.time()
+start.time = Sys.time()
 num_dimensions <- c(10, 50, 100)
 for (dimension in num_dimensions) {
   num_particles <- 4*dimension
@@ -65,7 +65,7 @@ for (dimension in num_dimensions) {
   eki_result <- eki_normal(num_particles, true_parameters, prior_params, adaptive = adaptive)
   plot_eki_normal(eki_result, true_parameters, prior_params)
 }
-end.time <- Sys.time()
+end.time = Sys.time()
 end.time - start.time
 ```
 

--- a/results/results_eki_normal.Rmd
+++ b/results/results_eki_normal.Rmd
@@ -57,6 +57,7 @@ prior_params <- list(alpha.mean = 0, alpha.sd = 5,
 In this experiment I keep $\alpha$ and $\sigma^2$ fixed at 2 and 4 respectively and let $x$ be a vector of 1s corresponding to 10, 50 and 100 dimensions. The purpose of this is to see how the EKI algorithm performs when the number of dimensions increases.
 
 ```{r}
+start.time <- Sys.time()
 num_dimensions <- c(10, 50, 100)
 for (dimension in num_dimensions) {
   num_particles <- 4*dimension
@@ -64,6 +65,8 @@ for (dimension in num_dimensions) {
   eki_result <- eki_normal(num_particles, true_parameters, prior_params, adaptive = adaptive)
   plot_eki_normal(eki_result, true_parameters, prior_params)
 }
+end.time <- Sys.time()
+end.time - start.time
 ```
 
 Generally speaking, the model does reasonably well at estimating $\alpha$ but appears to under-estimate the noise parameter. As the number of dimensions increases, the distribution of $\alpha$ becomes more concentrated, but the distribution of $\sigma^2$ does not demonstrate any noticeable pattern.

--- a/src/samples_normal.R
+++ b/src/samples_normal.R
@@ -26,6 +26,7 @@ likelihood_normal <- function(parameters) {
   x = parameters$x
   sigma2 = parameters$sigma**2
   dim = length(x)
+  print(dim)
   # print(sigma2)
   # print(sigma2*diag(dim))
   return(rmvnorm(1, mean = alpha*x, sigma = sigma2*diag(dim)))

--- a/src/samples_normal.R
+++ b/src/samples_normal.R
@@ -26,7 +26,7 @@ likelihood_normal <- function(parameters) {
   x = parameters$x
   sigma2 = parameters$sigma**2
   dim = length(x)
-  print(dim)
+  # print(dim)
   # print(sigma2)
   # print(sigma2*diag(dim))
   return(rmvnorm(1, mean = alpha*x, sigma = sigma2*diag(dim)))

--- a/src/utils/tempering.R
+++ b/src/utils/tempering.R
@@ -1,16 +1,16 @@
 pacman::p_load(pacman, purrr)
 
-get_sum_of_seq <- function(simulated_data, likelihood_samples, covariances, num_particles) {
+get_sum_of_sq <- function(simulated_data, likelihood_samples, covariances, num_particles) {
   
   C_y_given_x_inv <- covariances$C_y_given_x_inv
-  change_in_temp <- next_temp - current_temp
   difference <- simulated_data - likelihood_samples
-  sum_of_sq <- difference %*% C_y_given_x_inv %*% t(difference)
+  sum_of_sq <- diag(difference %*% C_y_given_x_inv %*% t(difference))
   return(sum_of_sq)
 }
 
 get_weights <- function(next_temp, current_temp, sum_of_sq) {
   
+  change_in_temp <- next_temp - current_temp
   weights <- exp(-1/2*change_in_temp*sum_of_sq)
   
   # print(length(weights))
@@ -37,7 +37,7 @@ get_ess_diff <- function(next_temp, current_temp, sum_of_sq, target_ess) {
 
 find_next_temp <- function(current_temp, simulated_data, likelihood_samples, covariances, num_particles, target_ess) {
   
-  sum_of_sq <- get_sum_of_seq(simulated_data, likelihood_samples, covariances, num_particles)
+  sum_of_sq <- get_sum_of_sq(simulated_data, likelihood_samples, covariances, num_particles)
   
   # print(current_temp)
   # print(dim(simulated_data))

--- a/tests/test_eki_normal.R
+++ b/tests/test_eki_normal.R
@@ -18,9 +18,11 @@ true_params_nd = list(alpha = 2, sigma = 2, x = rep(1, num_dimensions))
 particles <- initialise_normal_particles(num_particles, prior_params)
 
 likelihood_samples_1d <- synthetic_normal(num_particles, particles, true_params_1d)
-simulated_data_1d <- matrix(likelihood_normal(true_params_1d), nrow = num_particles, ncol = 1, byrow = T)
+single_sample <- likelihood_normal(true_params_1d)
+simulated_data_1d <- matrix(single_sample, nrow = num_particles, ncol = 1, byrow = T)
 
 likelihood_samples_2d <- synthetic_normal(num_particles, particles, true_params_2d)
+single_sample <- likelihood_normal(true_params_2d)
 simulated_data_2d <- matrix(likelihood_normal(true_params_2d), nrow = num_particles, ncol = 2, byrow = T)
 
 likelihood_samples_nd <- synthetic_normal(num_particles, particles, true_params_nd)
@@ -160,3 +162,22 @@ sum(is.infinite(particles))
 
 test <- c(-Inf, 1, 2)
 is.infinite(test)
+
+C_y_given_x_inv <- matrix(c(0.1, 0.13, 0.5, 2.3), nrow = 2, ncol = 2)
+
+weights <- rep(0, num_particles)
+for (particle in 1:num_particles) {
+  weights[particle] <- exp(-1/2*t((simulated_data_2d[particle, ] - likelihood_samples_2d[particle, ])) %*% (C_y_given_x_inv) %*% (simulated_data_2d[particle, ] - likelihood_samples_2d[particle, ]))
+  # weights[particle] <- exp(-1/2*change_in_temp*t((simulated_data[particle, ] - likelihood_samples[particle, ])) %*% (simulated_data[particle, ] - likelihood_samples[particle, ]))
+}
+weights <- weights/sum(weights)
+
+# weights <- exp(-1/2*t(single_sample - likelihood_samples_1d) %*% (single_sample - likelihood_samples_1d))
+# weights <- weights/sum(weights)
+
+test <- diag((simulated_data_2d - likelihood_samples_2d) %*% C_y_given_x_inv %*% t(simulated_data_2d - likelihood_samples_2d))
+
+weights <- exp(-1/2*test)
+weights <- weights/sum(weights)
+
+

--- a/tests/test_eki_normal.R
+++ b/tests/test_eki_normal.R
@@ -64,7 +64,8 @@ test_that('Dimensions of particles are correct', {
 })
 
 test_that('Dimensions of weights are correct', {
-  expect_equal(length(get_weights(0.1, 0, likelihood_samples_1d, simulated_data_1d, covariances_1d, num_particles)), num_particles)
+  sum_of_sq <- get_sum_of_sq(simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles)
+  expect_equal(length(get_weights(0.1, 0, sum_of_sq)), num_particles)
 })
 
 test_that('Dimensions of pertubations are correct', {
@@ -125,8 +126,10 @@ test_that('Covariance matrices are positive semi definite', {
 
 
 test_that('ESS is between 1 and N', {
-  expect_lte(estimate_ess(0.1, 0, simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles),  num_particles)
-  expect_gte(estimate_ess(0.1, 0, simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles),  1)
+  sum_of_sq <- get_sum_of_sq(simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles)
+  expect_lte(estimate_ess(0.1, 0, sum_of_sq),  num_particles)
+  expect_gte(estimate_ess(0.1, 0, sum_of_sq),  1)
+  expect_equal(estimate_ess(0, 0, sum_of_sq), num_particles)
 })
 
 test_that('Next selected temperature is always >= current_temp and <= 1', {
@@ -135,9 +138,9 @@ test_that('Next selected temperature is always >= current_temp and <= 1', {
 })
 
 test_next_temp_valid <- function(current_temp, simulated_data, likelihood_samples, covariances, num_particles, target_ess) {
-  
+  sum_of_sq <- get_sum_of_sq(simulated_data, likelihood_samples, covariances, num_particles)
   next_temp <- find_next_temp(current_temp, simulated_data, likelihood_samples, covariances, num_particles, target_ess)
-  return(abs(get_ess_diff(next_temp, current_temp, simulated_data, likelihood_samples, covariances, num_particles, target_ess)))
+  return(abs(get_ess_diff(next_temp, current_temp, sum_of_sq, target_ess)))
 }
 
 # ToDo: account for when next temperature is 1
@@ -147,37 +150,26 @@ test_that('Next selected temperature gives the correct ESS', {
   expect_lt(test_next_temp_valid(0.1, simulated_data_nd, likelihood_samples_nd, covariances_nd, num_particles, num_particles*0.5), 0.5)
 })
 
-test_next_temp_valid(0.1, simulated_data_nd, likelihood_samples_nd, covariances_nd, num_particles, num_particles*0.5)
-test_next_temp_valid(0.1, simulated_data_2d, likelihood_samples_2d, covariances_2d, num_particles, num_particles*0.5)
-test_next_temp_valid(0.1, simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles, num_particles*0.5)
-estimate_ess(0.2, 0.1, simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles)
+# test_next_temp_valid(0.1, simulated_data_nd, likelihood_samples_nd, covariances_nd, num_particles, num_particles*0.5)
+# test_next_temp_valid(0.1, simulated_data_2d, likelihood_samples_2d, covariances_2d, num_particles, num_particles*0.5)
+# test_next_temp_valid(0.1, simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles, num_particles*0.5)
+# estimate_ess(0.2, 0.1, simulated_data_1d, likelihood_samples_1d, covariances_1d, num_particles)
 
 
 # covariances_1d$C_yy
 # 
 # covariances_nd$C_yy
 # covariances_nd$C_y_given_x_inv
-sum(is.infinite(particles))
-
-
-test <- c(-Inf, 1, 2)
-is.infinite(test)
-
-C_y_given_x_inv <- matrix(c(0.1, 0.13, 0.5, 2.3), nrow = 2, ncol = 2)
-
-weights <- rep(0, num_particles)
-for (particle in 1:num_particles) {
-  weights[particle] <- exp(-1/2*t((simulated_data_2d[particle, ] - likelihood_samples_2d[particle, ])) %*% (C_y_given_x_inv) %*% (simulated_data_2d[particle, ] - likelihood_samples_2d[particle, ]))
-  # weights[particle] <- exp(-1/2*change_in_temp*t((simulated_data[particle, ] - likelihood_samples[particle, ])) %*% (simulated_data[particle, ] - likelihood_samples[particle, ]))
-}
-weights <- weights/sum(weights)
-
-# weights <- exp(-1/2*t(single_sample - likelihood_samples_1d) %*% (single_sample - likelihood_samples_1d))
-# weights <- weights/sum(weights)
-
-test <- diag((simulated_data_2d - likelihood_samples_2d) %*% C_y_given_x_inv %*% t(simulated_data_2d - likelihood_samples_2d))
-
-weights <- exp(-1/2*test)
-weights <- weights/sum(weights)
+# sum(is.infinite(particles))
+# 
+# 
+# test <- c(-Inf, 1, 2)
+# is.infinite(test)
+# 
+# x.true <- rep(1, 50)
+# current_params = list(alpha = particles[, 1], x = x.true, sigma = sqrt(exp(particles[, 2])))
+# likelihood_samples <- likelihood_normal(current_params)
+# 
+# rmvnorm(mean = rep(c(1,2,3), 3), sigma = rep(diag(3), 3))
 
 


### PR DESCRIPTION
Increase algorithm speed by vectorising calculation of weights and avoiding repeating the computation when using the root finding algorithm for the next temperature. Gives about a 10% speedup. 